### PR TITLE
Update trainer.py

### DIFF
--- a/lib/trainer.py
+++ b/lib/trainer.py
@@ -278,11 +278,11 @@ class Trainer(ResSCNNTrainer):
     compare2 = read_xlrd(self.config.test_file)
 
     mos = []
-    for y in compare1:
+    for y in compare2:
       mos.append(y[1])
 
     pred = []
-    for y in compare2:
+    for y in compare1:
       pred.append(y[1])
 
     _, _, pred = logistic_5_fitting_no_constraint(pred, mos)


### PR DESCRIPTION
fix: wrong assignment between mos and pred

似乎标签与预测值赋值语句写反了，导致计算RMSE指标不太正常